### PR TITLE
Disable Spelling

### DIFF
--- a/plugin/xterm-color-table.vim
+++ b/plugin/xterm-color-table.vim
@@ -1,4 +1,3 @@
-
 "   ___  __)                   )   ___                  ______)
 "  (,  |/                     (__/_____)   /)          (, /      /)  /)
 "      |  _/_  _  __  ____      /      ___// _____       /  _   (/_ //  _
@@ -142,6 +141,7 @@ function! <SID>SetBufferOptions()
     setlocal nomodified nomodifiable noswapfile readonly
     setlocal nocursorline nocursorcolumn
     setlocal iskeyword+=#
+    setlocal nospell
 
     let b:XtermColorTableRgbVisible = 0
     let b:XtermColorTableBGF = -2


### PR DESCRIPTION
My syntax highlighting marks misspellings in red, which in a way bypasses the toggle RGB visibility option.

Disabling spelling in for the buffer fixes this.
