### PR TITLE
add commands to highlight Xterm color code numbers

### DIFF
--- a/doc/xterm-color-table.txt
+++ b/doc/xterm-color-table.txt
@@ -29,6 +29,11 @@ Commands
 							*OXtermColorTable*
 :OXtermColorTable	Same, but (re)open and make it the only window
 
+							*XtermColorHighlight*
+:XtermColorHighlight	Highlight Xterm color code numbers (0 through 255)
+
+							*XtermColorHighlightOff*
+:XtermColorHighlightOff	Turn off highlighting for Xterm color code numbers
 
 ==============================================================================
 Options

--- a/plugin/xterm-color-table.vim
+++ b/plugin/xterm-color-table.vim
@@ -44,6 +44,8 @@ command! VXtermColorTable call <SID>XtermColorTable('vsplit')
 command! TXtermColorTable call <SID>XtermColorTable('tabnew')
 command! EXtermColorTable call <SID>XtermColorTable('edit')
 command! OXtermColorTable call <SID>XtermColorTable('edit') | only
+command! XtermColorHighlight call <SID>HighlightCodes(1)
+command! XtermColorHighlightOff call <SID>HighlightCodes(0)
 
 augroup XtermColorTable
     autocmd!
@@ -183,6 +185,19 @@ endfunction
 
 function! s:HighlightTable(bgf)
     for val in range(0, 0xff) | call s:HighlightCell(val, a:bgf) | endfor
+endfunction
+
+function! s:HighlightCodes(enable)
+    for val in range(0, 0xff)
+        " Clear extant values
+        execute 'silent! syntax clear fg_' . val
+        execute 'silent! highlight clear fg_' . val
+        if a:enable
+            let rgb = s:xterm_colors[val]
+            execute 'syntax match fg_' . val . ' "\%(^\|\<\|\D\)\@1<=' . val . '\%($\|\>\|\D\)\@1=" containedin=ALL'
+            execute 'highlight fg_' . val . ' ctermfg=' . val . ' guifg=' . rgb
+        endif
+    endfor
 endfunction
 
 function! s:SetRgbForeground(cword)


### PR DESCRIPTION
This patch adds two commands to highlight Xterm color code numbers:

  :XtermColorHighlight      turns on highlighting
  :XtermColorHighlightOff   turns off highlighting

This feature is _indispensable_ if you have to configure colors for
curses-based applications (such as tmux and weechat) that make you
specify colors as raw Xterm color code numbers (0 through 255).