### PR TITLE
Change the way syntax match is executed.

### DIFF
--- a/plugin/xterm-color-table.vim
+++ b/plugin/xterm-color-table.vim
@@ -102,7 +102,7 @@ function! s:ColorCell(n)
     execute 'silent! syntax clear bg_' . a:n
 
     execute 'syntax match fg_' . a:n . ' " ' . a:n . ' " containedin=ALL'
-    execute 'syntax match bg_' . a:n . ' "'  . rgb . '" containedin=ALL'
+	execute 'syntax match bg_' . a:n . ' " ' . a:n . ' #[a-f0-9]\{6\}" containedin=ALL contains=fg_' . a:n
 
     call s:HighlightCell(a:n, -1)
 


### PR DESCRIPTION
Problem: The syntax highlight group is defined based on the RGB code used, which causes problems if 2 colors use the same RGB (e.g. if you redefine xterm ANSI colors in `.Xresources`). It can create the following (Note the colors 16, 21 and 51):
![Screenshot from 2019-10-13 20-00-10](https://user-images.githubusercontent.com/211438/66719874-ac992980-edf5-11e9-82a5-8f5bd5a4e3bb.png)

It can be reproduced by modifying the ANSI colors of the terminal. 

This PR makes the highlight independent from the rgb code used, as long as it is an RGB code.

Result afterwards:

![Screenshot from 2019-10-13 20-09-17](https://user-images.githubusercontent.com/211438/66719889-df432200-edf5-11e9-9290-b4f1dc85e4cc.png)
