### PR TITLE
Fix the URLs of the images in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,11 +21,11 @@ NOTES:
 
 SCREENSHOTS:
 
-![xterm-color-table](http://guns.github.com/xterm-color-table.vim/images/xterm-color-table.png)
+![xterm-color-table](https://guns.github.io/xterm-color-table.vim/images/xterm-color-table.png)
 
 With RGB visibility toggled:
 
-![xterm-color-table-with-visible-rgb](http://guns.github.com/xterm-color-table.vim/images/xterm-color-table-with-visible-rgb.png)
+![xterm-color-table-with-visible-rgb](https://guns.github.io/xterm-color-table.vim/images/xterm-color-table-with-visible-rgb.png)
 
 INSPIRED BY:
 


### PR DESCRIPTION
The URLs of the images in README is no longer available,
because GitHub Pages changed the domain names of users from _\<user\>.github.com_ to _\<user\>.github.io_.
On top of it, I changed the URI schemes from _HTTP_ to _HTTPS_.
Thanks!